### PR TITLE
Add additional history to bundled calendars (bacs, targetfrance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2 - May 5, 2020
+
+- Add 2011-2012 Bacs calendar
+- Add 2013-2017 Targetfrance calendar
+
 ## 1.0.1 - April 30, 2020
 
 - Correct Danish public holidays

--- a/business/data/bacs.yml
+++ b/business/data/bacs.yml
@@ -6,6 +6,22 @@ working_days:
   - friday
 
 holidays:
+  - January 3rd, 2011
+  - April 25th, 2011
+  - May 2nd, 2011
+  - May 30th, 2011
+  - August 29th, 2011
+  - December 26th, 2011
+  - December 27th, 2011
+  - January 2nd, 2012
+  - April 6th, 2012
+  - April 9th, 2012
+  - May 7th, 2012
+  - June 4th, 2012
+  - June 5th, 2012
+  - August 27th, 2012
+  - December 25th, 2012
+  - December 26th, 2012
   - January 1st, 2013
   - March 29th, 2013
   - April 1st, 2013

--- a/business/data/targetfrance.yml
+++ b/business/data/targetfrance.yml
@@ -1,6 +1,6 @@
 # The dates for Ascension Day and Whit Monday change each year. At the time of writing this comment (29/10/2019),
-# the dates for these holidays have only been published up till the year 2021. 
-# In this file, dates from the year 2022 onwards only consist of fixed/known bank holidays. 
+# the dates for these holidays have only been published up till the year 2021.
+# In this file, dates from the year 2022 onwards only consist of fixed/known bank holidays.
 
 working_days:
   - monday
@@ -10,6 +10,72 @@ working_days:
   - friday
 
 holidays:
+  - January 1st, 2013
+  - March 29th, 2013
+  - April 1st, 2013
+  - May 1st, 2013
+  - May 8th, 2013
+  - May 9th, 2013
+  - May 19th, 2013
+  - May 20th, 2013
+  - July 14th, 2013
+  - August 15th, 2013
+  - November 1st, 2013
+  - November 11th, 2013
+  - December 25th, 2013
+  - December 26th, 2013
+  - January 1st, 2014
+  - April 18th, 2014
+  - April 21st, 2014
+  - May 1st, 2014
+  - May 8th, 2014
+  - May 29th, 2014
+  - June 9th, 2014
+  - July 14th, 2014
+  - August 15th, 2014
+  - November 1st, 2014
+  - November 11th, 2014
+  - December 25th, 2014
+  - December 26th, 2014
+  - January 1st, 2015
+  - April 3rd, 2015
+  - April 6th, 2015
+  - May 1st, 2015
+  - May 8th, 2015
+  - May 14th, 2015
+  - May 25th, 2015
+  - July 14th, 2015
+  - August 15th, 2015
+  - November 1st, 2015
+  - November 11th, 2015
+  - December 25th, 2015
+  - December 26th, 2015
+  - January 1st, 2016
+  - March 25th, 2016
+  - March 28th, 2016
+  - May 1st, 2016
+  - May 5th, 2016
+  - May 8th, 2016
+  - May 16th, 2016
+  - July 14th, 2016
+  - August 15th, 2016
+  - November 1st, 2016
+  - November 11th, 2016
+  - December 25th, 2016
+  - December 26th, 2016
+  - January 1st, 2017
+  - April 14th, 2017
+  - April 17th, 2017
+  - May 1st, 2017
+  - May 8th, 2017
+  - May 25th, 2017
+  - June 5th, 2017
+  - July 14th, 2017
+  - August 15th, 2017
+  - November 1st, 2017
+  - November 11th, 2017
+  - December 25th, 2017
+  - December 26th, 2017
   - January 1st, 2018
   - March 30th, 2018
   - April 2nd, 2018
@@ -27,104 +93,104 @@ holidays:
   - April 19th, 2019
   - April 22nd, 2019
   - May 1st, 2019
-  - May 8th, 2019 
-  - May 30th, 2019 
-  - June 10th, 2019 
-  - July 14th, 2019 
-  - August 15th, 2019 
-  - November 1st, 2019 
-  - November 11th, 2019 
+  - May 8th, 2019
+  - May 30th, 2019
+  - June 10th, 2019
+  - July 14th, 2019
+  - August 15th, 2019
+  - November 1st, 2019
+  - November 11th, 2019
   - December 25th, 2019
   - December 26th, 2019
   - January 1st, 2020
   - April 10th, 2020
   - April 13th, 2020
   - May 1st, 2020
-  - May 8th, 2020 
-  - May 21st, 2020 
-  - June 1st, 2020 
-  - July 14th, 2020 
-  - August 15th, 2020 
-  - November 1st, 2020 
-  - November 11th, 2020 
+  - May 8th, 2020
+  - May 21st, 2020
+  - June 1st, 2020
+  - July 14th, 2020
+  - August 15th, 2020
+  - November 1st, 2020
+  - November 11th, 2020
   - December 25th, 2020
   - December 26th, 2020
   - January 1st, 2021
   - April 2nd, 2021
   - April 5th, 2021
   - May 1st, 2021
-  - May 8th, 2021 
-  - May 13th, 2021 
-  - May 24th, 2021 
-  - July 14th, 2021 
-  - August 15th, 2021 
-  - November 1st, 2021 
-  - November 11th, 2021 
+  - May 8th, 2021
+  - May 13th, 2021
+  - May 24th, 2021
+  - July 14th, 2021
+  - August 15th, 2021
+  - November 1st, 2021
+  - November 11th, 2021
   - December 25th, 2021
   - December 26th, 2021
   - January 1st, 2022
   - April 15th, 2022
   - April 18th, 2022
   - May 1st, 2022
-  - May 8th, 2022 
-  - July 14th, 2022 
-  - August 15th, 2022 
-  - November 1st, 2022 
-  - November 11th, 2022 
+  - May 8th, 2022
+  - July 14th, 2022
+  - August 15th, 2022
+  - November 1st, 2022
+  - November 11th, 2022
   - December 25th, 2022
   - December 26th, 2022
   - January 1st, 2023
   - April 7th, 2023
   - April 10th, 2023
   - May 1st, 2023
-  - May 8th, 2023 
-  - July 14th, 2023 
-  - August 15th, 2023 
-  - November 1st, 2023 
-  - November 11th, 2023 
+  - May 8th, 2023
+  - July 14th, 2023
+  - August 15th, 2023
+  - November 1st, 2023
+  - November 11th, 2023
   - December 25th, 2023
   - December 26th, 2023
   - January 1st, 2024
   - March 29th, 2024
   - April 1st, 2024
   - May 1st, 2024
-  - May 8th, 2024 
-  - July 14th, 2024 
-  - August 15th, 2024 
-  - November 1st, 2024 
-  - November 11th, 2024 
+  - May 8th, 2024
+  - July 14th, 2024
+  - August 15th, 2024
+  - November 1st, 2024
+  - November 11th, 2024
   - December 25th, 2024
   - December 26th, 2024
   - January 1st, 2025
   - April 18th, 2025
   - April 21st, 2025
   - May 1st, 2025
-  - May 8th, 2025 
-  - July 14th, 2025 
-  - August 15th, 2025 
-  - November 1st, 2025 
-  - November 11th, 2025 
+  - May 8th, 2025
+  - July 14th, 2025
+  - August 15th, 2025
+  - November 1st, 2025
+  - November 11th, 2025
   - December 25th, 2025
   - December 26th, 2025
   - January 1st, 2026
   - April 3rd, 2026
   - April 6th, 2026
   - May 1st, 2026
-  - May 8th, 2026 
-  - July 14th, 2026 
-  - August 15th, 2026 
-  - November 1st, 2026 
-  - November 11th, 2026 
+  - May 8th, 2026
+  - July 14th, 2026
+  - August 15th, 2026
+  - November 1st, 2026
+  - November 11th, 2026
   - December 25th, 2026
   - December 26th, 2026
   - January 1st, 2027
   - March 26th, 2027
   - March 29th, 2027
   - May 1st, 2027
-  - May 8th, 2027 
-  - July 14th, 2027 
-  - August 15th, 2027 
-  - November 1st, 2027 
-  - November 11th, 2027 
+  - May 8th, 2027
+  - July 14th, 2027
+  - August 15th, 2027
+  - November 1st, 2027
+  - November 11th, 2027
   - December 25th, 2027
   - December 26th, 2027

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "business-python"
-version = "1.0.1"
+version = "1.0.2"
 description = "Date calculations based on business calendars."
 authors = ["GoCardless <engineering@gocardless.com>"]
 readme = "README.md"


### PR DESCRIPTION
This PR adds additional history to some calendars:
- bacs: add 2011-2012 holidays
- targetfrance: add 2013-2017 holidays 