### PR TITLE
Add py.typed file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2 - July 25, 2021
+- add py.typed file to indicate to mypy that the library is fully type annotated.
+
 ## 2.0.1 - April 28, 2021
 - widen range of `importlib_metadata` to include 4.x.x release
 - CircleCI: bump poetry/pip to latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "business-python"
-version = "2.0.1"
+version = "2.0.2"
 description = "Date calculations based on business calendars."
 authors = ["GoCardless <engineering@gocardless.com>"]
 readme = "README.md"


### PR DESCRIPTION
This indicates to mypy that the library is fully typed when importing it into a project.

Also bump to version 2.0.2.