### PR TITLE
Stricter type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3 - August 2, 2021
+- stricter type checking
+
 ## 2.0.2 - July 25, 2021
 - add py.typed file to indicate to mypy that the library is fully type annotated.
 

--- a/business/__init__.py
+++ b/business/__init__.py
@@ -1,7 +1,8 @@
 """Init."""
+# mypy: ignore-errors
 
 
-def get_version():
+def get_version() -> str:
     """Get package version."""
     try:
         from importlib.metadata import version

--- a/business/calendar.py
+++ b/business/calendar.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import os
 from threading import RLock
-from typing import List, Optional, Union
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
 import yaml
 from dateutil.parser import parse as dateutil_parse
@@ -12,23 +12,24 @@ logger = logging.getLogger("business")
 
 day_interval = datetime.timedelta(days=1)
 INPUT_TYPES = Union[str, datetime.date]
+T = TypeVar('T')
 
 
-class Mutex:
+class Mutex(Generic[T]):
     """Helper class for thread-safe locking."""
 
-    def __init__(self, obj):
+    def __init__(self, obj: T) -> None:
         """Initialise reentrant lock."""
         super().__init__()
         self.__obj = obj
         self.lock = RLock()
 
-    def __enter__(self):
+    def __enter__(self) -> T:
         """Acquire lock on entering."""
         self.lock.acquire()
         return self.__obj
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
         """Release lock on exit."""
         self.lock.release()
 
@@ -36,7 +37,7 @@ class Mutex:
 class Calendar:
     """Calendar class."""
 
-    _cache = Mutex(dict())
+    _cache: Mutex[Dict[str, "Calendar"]] = Mutex(dict())
 
     load_paths: List[str] = []
 
@@ -68,7 +69,7 @@ class Calendar:
                 raise ValueError(f"Extra working dates cannot be on working days: {d}")
 
     @classmethod
-    def load(cls, calendar_str: str):
+    def load(cls, calendar_str: str) -> "Calendar":
         """Load a scheme calendar YAML file.
 
         >>> %timeit -n 100 Calendar.load('bacs')
@@ -105,7 +106,7 @@ class Calendar:
         )
 
     @classmethod
-    def load_cache(cls, calendar_str: str):
+    def load_cache(cls, calendar_str: str) -> "Calendar":
         """Load a scheme calendar YAML file with cache.
 
         >>> %timeit Calendar.load_cache('bacs')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ target-version = ['py36']
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "business-python"
-version = "2.0.2"
+version = "2.0.3"
 description = "Date calculations based on business calendars."
 authors = ["GoCardless <engineering@gocardless.com>"]
 readme = "README.md"


### PR DESCRIPTION
We need to provide a type for the return value of `load` and
`load_cache`, otherwise mypy is unable to infer the types of calling any
methods on an instance returned from there, defeating the whole point of
annotating the class. Since the class is not yet defined at that point,
we use a string literal to define the type. (Once we drop support for
Python 3.6, we can use `from __future__ import annotations` which will
allow us to use the class itself there without breaking the code.)

For completeness, also annotate Mutex by making it a generic and
declaring a concrete type for the calendar _cache classvar.